### PR TITLE
Remove whitespaces from PHP versions for charts

### DIFF
--- a/src/Entity/Mautic3UpgradeStats.php
+++ b/src/Entity/Mautic3UpgradeStats.php
@@ -176,7 +176,7 @@ class Mautic3UpgradeStats
      */
     public function setVersion($version)
     {
-        $this->version = $version;
+        $this->version = trim($version);
 
         return $this;
     }
@@ -188,7 +188,7 @@ class Mautic3UpgradeStats
      */
     public function getVersion()
     {
-        return $this->version;
+        return trim($this->version);
     }
 
     /**


### PR DESCRIPTION
This PR removes whitespaces from PHP versions, because of which the charts currently don't render on the M3 upgrade statistics: 

![image](https://user-images.githubusercontent.com/17739158/84770247-7bea3f00-afd7-11ea-800a-77914c347cb2.png)

This fix was already done for the regular charts (https://github.com/mautic/statsapp/pull/3/files#diff-f7db2d445d80dae896f6bb6f9fe63bc0R172) but the changes mentioned in that commit weren't in the Git repo. This PR also adds the `trim` functionality to the M3 upgrade charts 🚀 